### PR TITLE
Add a regression test "suite"

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -367,7 +367,7 @@ export function getSegmentSegmentIntersection(
 /**
  * Get the intersection points between a line segment and a rectangle with rounded corners.
  * @param x0 The x-axis coordinate of the segment's starting point.
- * @param y0 The y-axis coordinate of ththe segment's ending point.
+ * @param y0 The y-axis coordinate of the segment's ending point.
  * @param x1 The delta-x of the ray.
  * @param y1 The delta-y of the ray.
  * @param x The x-axis coordinate of the rectangle.

--- a/test/__snapshots__/getArrow.test.ts.snap
+++ b/test/__snapshots__/getArrow.test.ts.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getArrow it computes a bowwed arrow between points 1`] = `
+Array [
+  10,
+  10,
+  21.476103837238064,
+  -19.022076744761318,
+  30,
+  11,
+  1.2941554536186235,
+  1.9473539914150553,
+  0.049958395721942765,
+]
+`;
+
+exports[`getArrow it computes an arrow between points 1`] = `
+Array [
+  10,
+  10,
+  20,
+  20,
+  30,
+  30,
+  0.7853981633974483,
+  0.7853981633974483,
+  0.7853981633974483,
+]
+`;
+
+exports[`getArrow it computes an arrow from a point back to itself 1`] = `
+Array [
+  10,
+  10,
+  10,
+  10,
+  10,
+  10,
+  0,
+  0,
+  0,
+]
+`;

--- a/test/__snapshots__/getBoxToBoxArrow.test.ts.snap
+++ b/test/__snapshots__/getBoxToBoxArrow.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getBoxToBoxArrow it computes an arrow between boxes 1`] = `
+Array [
+  10,
+  10.000000000000002,
+  10.000000000000004,
+  10.000000000000004,
+  10,
+  10.000000000000007,
+  2.356194490192345,
+  -2.677945044588987,
+  0.7853981633974483,
+]
+`;
+
+exports[`getBoxToBoxArrow it computes an arrow between boxes with straights disabled 1`] = `
+Array [
+  10,
+  10.000000000000002,
+  10.000000000000004,
+  10.000000000000004,
+  10,
+  10.000000000000007,
+  2.356194490192345,
+  -2.677945044588987,
+  0.7853981633974483,
+]
+`;
+
+exports[`getBoxToBoxArrow it computes an arrow from a box back to itself 1`] = `
+Array [
+  10,
+  15,
+  -2.388680238973927e-15,
+  5.000000000000002,
+  -10,
+  15.000000000000004,
+  2.356194490192345,
+  0.7853981633974482,
+  0,
+]
+`;
+
+exports[`getBoxToBoxArrow it computes an arrow from a box back to itsself 1`] = `
+Array [
+  10,
+  15,
+  -2.388680238973927e-15,
+  5.000000000000002,
+  -10,
+  15.000000000000004,
+  2.356194490192345,
+  0.7853981633974482,
+  0,
+]
+`;
+
+exports[`getBoxToBoxArrow it computes an arrow from a large box to a small box 1`] = `
+Array [
+  10,
+  358.6644951140066,
+  295,
+  203.6319218241043,
+  580,
+  48.599348534201965,
+  -0.4982049089769774,
+  2.643387744612816,
+  -0.49820490897697733,
+]
+`;

--- a/test/getArrow.test.ts
+++ b/test/getArrow.test.ts
@@ -1,0 +1,16 @@
+import { getArrow} from "../src"
+
+describe("getArrow", () => {
+  test("it computes an arrow between points", () => {
+    expect(getArrow(10, 10, 30, 30)).toMatchSnapshot()
+  })
+
+  test("it computes an arrow from a point back to itself", () => {
+    expect(getArrow(10, 10, 10, 10)).toMatchSnapshot()
+  })
+
+  test("it computes a bowwed arrow between points", () => {
+    expect(getArrow(10, 10, 30, 11, {bow: 1})).toMatchSnapshot()
+  })
+
+})

--- a/test/getBoxToBoxArrow.test.ts
+++ b/test/getBoxToBoxArrow.test.ts
@@ -1,0 +1,20 @@
+import { getBoxToBoxArrow} from "../src"
+
+describe("getBoxToBoxArrow", () => {
+  test("it computes an arrow between boxes", () => {
+    expect(getBoxToBoxArrow(10, 10, 10, 10, 30, 30, 10, 10)).toMatchSnapshot()
+  })
+
+  test("it computes an arrow from a large box to a small box", () => {
+    expect(getBoxToBoxArrow(10, 10, 576, 384, 600, 30, 10, 10)).toMatchSnapshot()
+  })
+
+  test("it computes an arrow from a box back to itself", () => {
+    expect(getBoxToBoxArrow(10, 10, 10, 10, 10, 10, 10, 10)).toMatchSnapshot()
+  })
+
+  test("it computes an arrow between boxes with straights disabled", () => {
+    expect(getBoxToBoxArrow(10, 10, 10, 10, 30, 30, 10, 10, {straights: false})).toMatchSnapshot()
+  })
+
+})


### PR DESCRIPTION
While fiddling with various pieces of the algorithms it's nice to know you haven't broken anything, and which situations have changed outputs. This adds a really lightweight test suite that ensures the APIs always work, and that changes to what arrows are being rendered at least require a snapshot update. It doesn't enforce that the arrows are correct or look perfect, but it at least arms developers with the knowledge of what they are changing so they can inspect it or fix it if it's unexpected.

I don't want to add extra work during development for no reason, but I wasn't sure if I was breaking stuff as I made changes so I'd appreciate something like this as a contributor. 