### PR TITLE
Remove unnecessary `peerDependencies` key

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "lint": "tsdx lint",
     "prepare": "tsdx build"
   },
-  "peerDependencies": {},
   "husky": {
     "hooks": {
       "pre-commit": "tsdx lint"


### PR DESCRIPTION
The value is an empty object, so is unnecessary.